### PR TITLE
Exclude static-class check in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,9 @@ dotnet_diagnostic.CA1307.severity = none
 dotnet_diagnostic.CA1310.severity = none
 dotnet_diagnostic.CA1311.severity = none
 
+# Don't need to mark sample test classes static
+dotnet_diagnostic.CA1812.severity = none
+
 # We accept logging performance is not important in samples
 dotnet_diagnostic.CA1848.severity = none
 


### PR DESCRIPTION
## What was changed

Like https://github.com/temporalio/sdk-dotnet/pull/21, ARM builds here are triggering https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812 and we don't want that checked