### PR TITLE
Use start-to-close

### DIFF
--- a/src/ActivitySimple/MyWorkflow.workflow.cs
+++ b/src/ActivitySimple/MyWorkflow.workflow.cs
@@ -15,7 +15,7 @@ public class MyWorkflow
             (MyActivities act) => act.SelectFromDatabaseAsync("some-db-table"),
             new()
             {
-                ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                StartToCloseTimeout = TimeSpan.FromMinutes(5),
             });
         Workflow.Logger.LogInformation("Activity instance method result: {Result}", result1);
 
@@ -25,7 +25,7 @@ public class MyWorkflow
             () => MyActivities.DoStaticThing(),
             new()
             {
-                ScheduleToCloseTimeout = TimeSpan.FromMinutes(5),
+                StartToCloseTimeout = TimeSpan.FromMinutes(5),
             });
         Workflow.Logger.LogInformation("Activity static method result: {Result}", result2);
 


### PR DESCRIPTION
## What was changed
Use start-to-close instead of schedule-to-close.

## Why?
Best practice to use start to close https://docs.temporal.io/activities#schedule-to-close-timeout

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/samples-dotnet/issues/17

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
