### PR TITLE
Makes AesGcm Sample Thread Safe

### DIFF
--- a/src/Encryption/Codec/EncryptionCodec.cs
+++ b/src/Encryption/Codec/EncryptionCodec.cs
@@ -16,7 +16,6 @@ public sealed class EncryptionCodec : IPayloadCodec, IDisposable
 
     private readonly byte[] KeyBytes;
     private readonly ByteString keyIDByteString;
-    private readonly AesGcm aes;
 
     public EncryptionCodec(string keyID = DefaultKeyID, string? key = DefaultKey)
     {

--- a/src/Encryption/Codec/EncryptionCodec.cs
+++ b/src/Encryption/Codec/EncryptionCodec.cs
@@ -17,11 +17,11 @@ public sealed class EncryptionCodec : IPayloadCodec
     private readonly byte[] key;
     private readonly ByteString keyIDByteString;
 
-    public EncryptionCodec(string keyID = DefaultKeyID, byte[]? _key = DefaultKey)
+    public EncryptionCodec(string keyID = DefaultKeyID, byte[]? key)
     {
         KeyID = keyID;
         keyIDByteString = ByteString.CopyFromUtf8(keyID);
-        key = _key;
+        this.key = key ?? DefaultKey;
     }
 
     public string KeyID { get; private init; }

--- a/src/Encryption/Codec/EncryptionCodec.cs
+++ b/src/Encryption/Codec/EncryptionCodec.cs
@@ -71,7 +71,8 @@ public sealed class EncryptionCodec : IPayloadCodec
         RandomNumberGenerator.Fill(nonceSpan);
 
         // Perform encryption
-        using (var aes = new AesGcm(key)) {
+        using (var aes = new AesGcm(key))
+        {
             aes.Encrypt(nonceSpan, data, bytes.AsSpan(NonceSize + TagSize), bytes.AsSpan(NonceSize, TagSize));
             return bytes;
         }
@@ -81,7 +82,8 @@ public sealed class EncryptionCodec : IPayloadCodec
     {
         var bytes = new byte[data.Length - NonceSize - TagSize];
 
-        using (var aes = new AecGcm(key)) {
+        using (var aes = new AesGcm(key))
+        {
             aes.Decrypt(
                 data.AsSpan(0, NonceSize), data.AsSpan(NonceSize + TagSize), data.AsSpan(NonceSize, TagSize), bytes.AsSpan());
             return bytes;

--- a/src/Encryption/Codec/EncryptionCodec.cs
+++ b/src/Encryption/Codec/EncryptionCodec.cs
@@ -17,7 +17,7 @@ public sealed class EncryptionCodec : IPayloadCodec
     private readonly byte[] key;
     private readonly ByteString keyIDByteString;
 
-    public EncryptionCodec(string keyID = DefaultKeyID, byte[]? key)
+    public EncryptionCodec(string keyID = DefaultKeyID, byte[]? key = null)
     {
         KeyID = keyID;
         keyIDByteString = ByteString.CopyFromUtf8(keyID);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Changed Encryption Codec in Encryption Sample to use a new instance of AesGcm on each call.

## Why?
<!-- Tell your future self why have you made these changes -->
See #50 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> #50 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them --> Ran several thousand simultaneous workflows

3. Any docs updates needed? No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
