### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload test failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-fail-${{ matrix.os }}
           path: tests/TestResults


### PR DESCRIPTION
## What was changed

- Updated all GHA actions to latest.

## Why?

- GitHub is pulling the plug on `upload-artifact@v2` on June 30th;
- All GHA official actions based on Node 16 are deprecated.
