### PR TITLE
Ready: timer sample was failing on running worker

### DIFF
--- a/src/Timer/MyActivities.cs
+++ b/src/Timer/MyActivities.cs
@@ -1,7 +1,9 @@
 namespace TemporalioSamples.Timer;
 
+using System.Diagnostics.CodeAnalysis;
 using Temporalio.Activities;
 
+[SuppressMessage("Design", "CA1052:Type 'MyActivities' is a static holder type but is neither static nor NotInheritable", Justification = "Class is designed for instantiation.")]
 public class MyActivities
 {
     [Activity]

--- a/src/Timer/Subscription.workflow.cs
+++ b/src/Timer/Subscription.workflow.cs
@@ -1,6 +1,7 @@
 namespace TemporalioSamples.Timer;
 
 using Microsoft.Extensions.Logging;
+using Temporalio.Exceptions;
 using Temporalio.Workflows;
 
 [Workflow]


### PR DESCRIPTION
# Fixing Timer Example

The timer example was failing when I ran `dotnet run worker`, so I just made small changes to get it running.

## The error

```
$ dotnet run worker

/Users/grantsmith/forks/samples-dotnet/src/Timer/Subscription.workflow.cs(24,35): error CS0103: The name 'TemporalException' does not exist in the current context [/Users/grantsmith/forks/samples-dotnet/src/Timer/TemporalioSamples.Timer.csproj]
/Users/grantsmith/forks/samples-dotnet/src/Timer/MyActivities.cs(5,14): error CA1052: Type 'MyActivities' is a static holder type but is neither static nor NotInheritable (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1052) [/Users/grantsmith/forks/samples-dotnet/src/Timer/TemporalioSamples.Timer.csproj]

The build failed. Fix the build errors and run again.
```


## The Fix

I just suppressed the message and added the exceptions import