### PR TITLE
update samples to use env config

### DIFF
--- a/src/ActivityHeartbeatingCancellation/Program.cs
+++ b/src/ActivityHeartbeatingCancellation/Program.cs
@@ -1,17 +1,21 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Exceptions;
 using Temporalio.Worker;
 using TemporalioSamples.ActivityHeartbeatingCancellation;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/ActivitySimple/Program.cs
+++ b/src/ActivitySimple/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.ActivitySimple;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/ActivityWorker/Program.cs
+++ b/src/ActivityWorker/Program.cs
@@ -1,11 +1,17 @@
 using Temporalio.Activities;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using Temporalio.Workflows;
 using TemporalioSamples.ActivityWorker;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233"));
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
+{
+    connectOptions.TargetHost = "localhost:7233";
+}
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 // Create worker
 using var worker = new TemporalWorker(

--- a/src/Bedrock/Basic/Program.cs
+++ b/src/Bedrock/Basic/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Extensions.Hosting;
 using TemporalioSamples.Bedrock.Basic;
 
@@ -47,14 +48,19 @@ async Task SendMessageAsync()
     Console.WriteLine($"Result: {result.Response}");
 }
 
-async Task<ITemporalClient> CreateClientAsync() =>
-    await TemporalClient.ConnectAsync(new("localhost:7233")
+async Task<ITemporalClient> CreateClientAsync()
+{
+    var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+    if (string.IsNullOrEmpty(connectOptions.TargetHost))
     {
-        LoggerFactory = LoggerFactory.Create(builder =>
-            builder.
-                AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-                SetMinimumLevel(LogLevel.Information)),
-    });
+        connectOptions.TargetHost = "localhost:7233";
+    }
+    connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+        builder.
+            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+            SetMinimumLevel(LogLevel.Information));
+    return await TemporalClient.ConnectAsync(connectOptions);
+}
 
 switch (args.ElementAtOrDefault(0))
 {

--- a/src/Bedrock/Entity/Program.cs
+++ b/src/Bedrock/Entity/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Extensions.Hosting;
 using TemporalioSamples.Bedrock.Entity;
 
@@ -78,14 +79,19 @@ async Task EndChatAsync()
     await handle.SignalAsync((workflow) => workflow.EndChatAsync());
 }
 
-async Task<ITemporalClient> CreateClientAsync() =>
-    await TemporalClient.ConnectAsync(new("localhost:7233")
+async Task<ITemporalClient> CreateClientAsync()
+{
+    var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+    if (string.IsNullOrEmpty(connectOptions.TargetHost))
     {
-        LoggerFactory = LoggerFactory.Create(builder =>
-            builder.
-                AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-                SetMinimumLevel(LogLevel.Information)),
-    });
+        connectOptions.TargetHost = "localhost:7233";
+    }
+    connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+        builder.
+            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+            SetMinimumLevel(LogLevel.Information));
+    return await TemporalClient.ConnectAsync(connectOptions);
+}
 
 switch (args.ElementAtOrDefault(0))
 {

--- a/src/Bedrock/SignalsAndQueries/Program.cs
+++ b/src/Bedrock/SignalsAndQueries/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Extensions.Hosting;
 using TemporalioSamples.Bedrock.SignalsAndQueries;
 
@@ -69,14 +70,19 @@ async Task GetHistoryAsync()
     }
 }
 
-async Task<ITemporalClient> CreateClientAsync() =>
-    await TemporalClient.ConnectAsync(new("localhost:7233")
+async Task<ITemporalClient> CreateClientAsync()
+{
+    var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+    if (string.IsNullOrEmpty(connectOptions.TargetHost))
     {
-        LoggerFactory = LoggerFactory.Create(builder =>
-            builder.
-                AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-                SetMinimumLevel(LogLevel.Information)),
-    });
+        connectOptions.TargetHost = "localhost:7233";
+    }
+    connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+        builder.
+            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+            SetMinimumLevel(LogLevel.Information));
+    return await TemporalClient.ConnectAsync(connectOptions);
+}
 
 switch (args.ElementAtOrDefault(0))
 {

--- a/src/ContextPropagation/Program.cs
+++ b/src/ContextPropagation/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Converters;
 using Temporalio.Worker;
 using TemporalioSamples.ContextPropagation;
@@ -11,17 +12,20 @@ using var loggerFactory = LoggerFactory.Create(builder =>
 var logger = loggerFactory.CreateLogger<Program>();
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = loggerFactory,
-    // This is where we set the interceptor to propagate context
-    Interceptors = new[]
-    {
-        new ContextPropagationInterceptor<string>(
-            MyContext.UserId,
-            DataConverter.Default.PayloadConverter),
-    },
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = loggerFactory;
+// This is where we set the interceptor to propagate context
+connectOptions.Interceptors = new[]
+{
+    new ContextPropagationInterceptor<string>(
+        MyContext.UserId,
+        DataConverter.Default.PayloadConverter),
+};
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/CounterInterceptor/Program.cs
+++ b/src/CounterInterceptor/Program.cs
@@ -1,6 +1,7 @@
 ﻿namespace TemporalioSamples.CounterInterceptor;
 
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 
 internal class Program
@@ -8,14 +9,16 @@ internal class Program
     private static async Task Main(string[] args)
     {
         var counterInterceptor = new MyCounterInterceptor();
-        var client = await TemporalClient.ConnectAsync(
-            options: new("localhost:7233")
-            {
-                Interceptors = new[]
-                {
-                    counterInterceptor,
-                },
-            });
+        var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+        if (string.IsNullOrEmpty(connectOptions.TargetHost))
+        {
+            connectOptions.TargetHost = "localhost:7233";
+        }
+        connectOptions.Interceptors = new[]
+        {
+            counterInterceptor,
+        };
+        var client = await TemporalClient.ConnectAsync(connectOptions);
 
         var activities = new MyActivities();
 

--- a/src/DependencyInjection/Program.cs
+++ b/src/DependencyInjection/Program.cs
@@ -1,4 +1,5 @@
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Extensions.Hosting;
 using TemporalioSamples.DependencyInjection;
 
@@ -25,13 +26,16 @@ async Task RunWorkerAsync()
 
 async Task ExecuteWorkflowAsync()
 {
-    var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+    var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+    if (string.IsNullOrEmpty(connectOptions.TargetHost))
     {
-        LoggerFactory = LoggerFactory.Create(builder =>
-            builder.
-                AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-                SetMinimumLevel(LogLevel.Information)),
-    });
+        connectOptions.TargetHost = "localhost:7233";
+    }
+    connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+        builder.
+            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+            SetMinimumLevel(LogLevel.Information));
+    var client = await TemporalClient.ConnectAsync(connectOptions);
 
     Console.WriteLine("Executing workflow");
     var result = await client.ExecuteWorkflowAsync(

--- a/src/Mutex/Program.cs
+++ b/src/Mutex/Program.cs
@@ -1,14 +1,19 @@
 ﻿using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.Mutex;
 using TemporalioSamples.Mutex.Impl;
 
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/Patching/Program.cs
+++ b/src/Patching/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.Patching;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/Polling/Frequent/Program.cs
+++ b/src/Polling/Frequent/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.Polling.Frequent;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/Polling/Infrequent/Program.cs
+++ b/src/Polling/Infrequent/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.Polling.Infrequent;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/Polling/PeriodicSequence/Program.cs
+++ b/src/Polling/PeriodicSequence/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.Polling.PeriodicSequence;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/SafeMessageHandlers/Program.cs
+++ b/src/SafeMessageHandlers/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.SafeMessageHandlers;
 
@@ -9,10 +10,13 @@ using var loggerFactory = LoggerFactory.Create(builder =>
     builder.
         AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
         SetMinimumLevel(LogLevel.Information));
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = loggerFactory,
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = loggerFactory;
+var client = await TemporalClient.ConnectAsync(connectOptions);
 var logger = loggerFactory.CreateLogger<Program>();
 
 async Task RunWorkerAsync()

--- a/src/Saga/Program.cs
+++ b/src/Saga/Program.cs
@@ -1,14 +1,18 @@
 ﻿using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.Saga;
 
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/Schedules/Program.cs
+++ b/src/Schedules/Program.cs
@@ -1,18 +1,22 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Api.Enums.V1;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Client.Schedules;
 using Temporalio.Worker;
 using TemporalioSamples.Schedules;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/SignalsQueries/Program.cs
+++ b/src/SignalsQueries/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.SignalsQueries;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/SleepForDays/Program.cs
+++ b/src/SleepForDays/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.SleepForDays;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/Timer/Program.cs
+++ b/src/Timer/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.Timer;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/UpdateWithStartEarlyReturn/Program.cs
+++ b/src/UpdateWithStartEarlyReturn/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.UpdateWithStartEarlyReturn;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 const string TaskQueue = "update-with-start-early-return";
 

--- a/src/UpdateWithStartLazyInit/Program.cs
+++ b/src/UpdateWithStartLazyInit/Program.cs
@@ -1,18 +1,22 @@
 using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Exceptions;
 using Temporalio.Worker;
 using TemporalioSamples.UpdateWithStartLazyInit;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 const string TaskQueue = "update-with-start-lazy-init";
 

--- a/src/WorkerSpecificTaskQueues/Program.cs
+++ b/src/WorkerSpecificTaskQueues/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.WorkerSpecificTaskQueues;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {

--- a/src/WorkerVersioning/Program.cs
+++ b/src/WorkerVersioning/Program.cs
@@ -1,5 +1,6 @@
 using Temporalio.Api.WorkflowService.V1;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Common;
 
 namespace TemporalioSamples.WorkerVersioning;
@@ -27,7 +28,12 @@ public static class Program
             return;
         }
 
-        var client = await TemporalClient.ConnectAsync(new("localhost:7233"));
+        var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+        if (string.IsNullOrEmpty(connectOptions.TargetHost))
+        {
+            connectOptions.TargetHost = "localhost:7233";
+        }
+        var client = await TemporalClient.ConnectAsync(connectOptions);
 
         switch (args[0].ToLower())
         {

--- a/src/WorkflowUpdate/Program.cs
+++ b/src/WorkflowUpdate/Program.cs
@@ -1,16 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Client;
+using Temporalio.Client.EnvConfig;
 using Temporalio.Worker;
 using TemporalioSamples.WorkflowUpdate;
 
 // Create a client to localhost on default namespace
-var client = await TemporalClient.ConnectAsync(new("localhost:7233")
+var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
+if (string.IsNullOrEmpty(connectOptions.TargetHost))
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
-});
+    connectOptions.TargetHost = "localhost:7233";
+}
+connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+var client = await TemporalClient.ConnectAsync(connectOptions);
 
 async Task RunWorkerAsync()
 {


### PR DESCRIPTION
## What was changed
Updated existing samples to use client environment configuration.

## Why?
Client environment configuration is intended as the standard way to configure clients going forward.

1. Part of https://github.com/temporalio/samples-dotnet/issues/101

2. How was this tested:
Existing test suite passes

3. Any docs updates needed?
No
