### PR TITLE
VLN-486: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - "releases/*"
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   build-lint-test:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a workflow-level permissions block limiting the token to contents: read plus actions: write so upload-artifact can create artifacts while other scopes default to none.