### PR TITLE
chore: Update and pin all GHA actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: 8
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload test failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: test-fail-${{ matrix.os }}
           path: tests/TestResults


### PR DESCRIPTION
## What changed

- Bump all GitHub Actions workflows to use latest "safe" releases.
  "Safe" is defined as the latest published release that is at least 2 weeks old (cooldown period).
- Pin all GHA actions usage to full SHA1, with a version comment.

## Why

- Improved security.
