### PR TITLE
Add ToolRegistryIncidentTriage sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Prerequisites:
 * [StandaloneActivity](src/StandaloneActivity) - Execute activities directly from a client, without a workflow.
 * [SleepForDays](src/SleepForDays/) - Use a timer to send an email every 30 days.
 * [Timer](src/Timer) - Use a timer to implement a monthly subscription; handle workflow cancellation.
+* [ToolRegistryIncidentTriage](src/ToolRegistryIncidentTriage) - LLM-driven incident triage activity using `Temporalio.Extensions.ToolRegistry`. Demonstrates `AgenticSession`, MCP HTTP integration, human-in-the-loop, and a testable activity refactor.
 * [UpdatableTimer](src/UpdatableTimer) - A timer that can be updated while sleeping.
 * [UpdateWithStartEarlyReturn](src/UpdateWithStartEarlyReturn) - Use update with start to get an early return, letting the rest of the workflow complete in the background.
 * [UpdateWithStartLazyInit](src/UpdateWithStartLazyInit) - Use update with start to lazily start a workflow before sending update.

--- a/TemporalioSamples.sln
+++ b/TemporalioSamples.sln
@@ -113,6 +113,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemporalioSamples.Standalon
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemporalioSamples.NexusMessaging", "src\NexusMessaging\TemporalioSamples.NexusMessaging.csproj", "{5D493692-53AB-4FAA-BA4D-33B1E54E9A48}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ToolRegistryIncidentTriage", "ToolRegistryIncidentTriage", "{35A8F06D-43CC-9D57-87FE-637F68C71095}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemporalioSamples.ToolRegistryIncidentTriage", "src\ToolRegistryIncidentTriage\TemporalioSamples.ToolRegistryIncidentTriage.csproj", "{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -663,6 +667,18 @@ Global
 		{5D493692-53AB-4FAA-BA4D-33B1E54E9A48}.Release|x64.Build.0 = Release|Any CPU
 		{5D493692-53AB-4FAA-BA4D-33B1E54E9A48}.Release|x86.ActiveCfg = Release|Any CPU
 		{5D493692-53AB-4FAA-BA4D-33B1E54E9A48}.Release|x86.Build.0 = Release|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Debug|x64.Build.0 = Debug|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Debug|x86.Build.0 = Debug|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Release|x64.ActiveCfg = Release|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Release|x64.Build.0 = Release|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Release|x86.ActiveCfg = Release|Any CPU
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -719,5 +735,7 @@ Global
 		{EAB0C45A-7620-D2D2-2901-5E7FCBFFDA77} = {1A647B41-53D0-4638-AE5A-6630BAAE45FC}
 		{240517A1-13B5-4A67-8519-BFCF2C4591B9} = {EAB0C45A-7620-D2D2-2901-5E7FCBFFDA77}
 		{5D493692-53AB-4FAA-BA4D-33B1E54E9A48} = {1A647B41-53D0-4638-AE5A-6630BAAE45FC}
+		{35A8F06D-43CC-9D57-87FE-637F68C71095} = {1A647B41-53D0-4638-AE5A-6630BAAE45FC}
+		{4FB1E024-A887-4C3E-A7FD-5523FE811A3B} = {35A8F06D-43CC-9D57-87FE-637F68C71095}
 	EndGlobalSection
 EndGlobal

--- a/src/ToolRegistryIncidentTriage/ApprovalWorkflow.cs
+++ b/src/ToolRegistryIncidentTriage/ApprovalWorkflow.cs
@@ -1,0 +1,44 @@
+using Temporalio.Workflows;
+
+namespace TemporalioSamples.ToolRegistryIncidentTriage;
+
+/// <summary>
+/// Companion HITL workflow.
+///
+/// The triage agent's request_human_approval tool calls SignalWithStartWorkflow
+/// against a deterministic ID per alert group. This workflow stores the latest
+/// request, exposes it as a query, and returns the operator's decision.
+/// </summary>
+[Workflow("approvalWorkflow")]
+public class ApprovalWorkflow
+{
+    private ApprovalRequest? request;
+    private ApprovalResponse? response;
+
+    [WorkflowRun]
+    public async Task<ApprovalResponse> RunAsync(string key)
+    {
+        // LLM retry: re-attached requests overwrite. Operator only ever
+        // sees the latest version, since the agent may refine its ask.
+        await Workflow.WaitConditionAsync(() => request != null);
+        await Workflow.WaitConditionAsync(() => response != null);
+        return response!;
+    }
+
+    [WorkflowSignal("approval-request")]
+    public Task ApprovalRequestAsync(ApprovalRequest req)
+    {
+        request = req;
+        return Task.CompletedTask;
+    }
+
+    [WorkflowSignal("approval-decision")]
+    public Task ApprovalDecisionAsync(ApprovalResponse res)
+    {
+        response = res;
+        return Task.CompletedTask;
+    }
+
+    [WorkflowQuery("pending-approval")]
+    public ApprovalRequest? PendingApproval() => request;
+}

--- a/src/ToolRegistryIncidentTriage/Client.cs
+++ b/src/ToolRegistryIncidentTriage/Client.cs
@@ -1,0 +1,83 @@
+// Standalone client CLI (dotnet run --project Client.csproj is convenient,
+// but for the demo this lives as a static method on the worker assembly,
+// invoked via `dotnet run -- <args>` after switching the project's OutputType
+// or via `dotnet TriageWorker.dll client <args>` once published.
+//
+// Listing pending approval workflows: use the Temporal CLI directly.
+using Temporalio.Client;
+using TemporalioSamples.ToolRegistryIncidentTriage;
+
+namespace TemporalioSamples.ToolRegistryIncidentTriage;
+
+public static class ClientCli
+{
+    public static async Task<int> RunAsync(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.Error.WriteLine("Usage: client <approve|reject|trigger> ...");
+            return 1;
+        }
+
+        var client = await MakeClientAsync().ConfigureAwait(false);
+        var cmd = args[0];
+        var rest = args.Skip(1).ToArray();
+
+        return cmd switch
+        {
+            "approve" when rest.Length >= 2 => await DecideAsync(client, "approved", rest[0], string.Join(" ", rest.Skip(1))),
+            "reject" when rest.Length >= 2 => await DecideAsync(client, "rejected", rest[0], string.Join(" ", rest.Skip(1))),
+            "trigger" when rest.Length >= 2 => await TriggerAsync(client, rest[0], rest[1]),
+            _ => Usage(cmd),
+        };
+    }
+
+    private static int Usage(string cmd)
+    {
+        Console.Error.WriteLine($"Unknown or malformed command: {cmd}");
+        Console.Error.WriteLine("Usage: client <approve|reject|trigger> ...");
+        return 1;
+    }
+
+    private static async Task<TemporalClient> MakeClientAsync()
+    {
+        var address = Environment.GetEnvironmentVariable("TEMPORAL_ADDRESS") ?? throw new InvalidOperationException("TEMPORAL_ADDRESS missing");
+        var ns = Environment.GetEnvironmentVariable("TEMPORAL_NAMESPACE") ?? throw new InvalidOperationException("TEMPORAL_NAMESPACE missing");
+        var apiKey = Environment.GetEnvironmentVariable("TEMPORAL_API_KEY") ?? throw new InvalidOperationException("TEMPORAL_API_KEY missing");
+        return await TemporalClient.ConnectAsync(new()
+        {
+            TargetHost = address,
+            Namespace = ns,
+            ApiKey = apiKey,
+            Tls = new() { },
+        });
+    }
+
+    private static async Task<int> DecideAsync(TemporalClient client, string decision, string workflowId, string reason)
+    {
+        var handle = client.GetWorkflowHandle<ApprovalWorkflow>(workflowId);
+        await handle.SignalAsync(wf => wf.ApprovalDecisionAsync(new ApprovalResponse(decision, reason)));
+        Console.WriteLine($"signaled {workflowId}: {decision} — {reason}");
+        return 0;
+    }
+
+    private static async Task<int> TriggerAsync(TemporalClient client, string alertname, string service)
+    {
+        var taskQueue = Environment.GetEnvironmentVariable("TEMPORAL_TASK_QUEUE") ?? "triage-dotnet";
+        var wfId = $"triage-{alertname.ToLowerInvariant()}-{service.ToLowerInvariant()}";
+        var alert = new AlertPayload(
+            Status: "firing",
+            Labels: new() { ["alertname"] = alertname, ["service"] = service, ["severity"] = "critical", ["runbook"] = "synthetic" },
+            Annotations: new()
+            {
+                ["summary"] = $"Synthetic test alert for {service}",
+                ["description"] = "Triggered manually via Client to exercise the triage flow.",
+            },
+            StartsAt: DateTime.UtcNow.ToString("o"));
+        var handle = await client.StartWorkflowAsync(
+            (IncidentTriageWorkflow w) => w.RunAsync(alert),
+            new(id: wfId, taskQueue: taskQueue));
+        Console.WriteLine($"started triage workflow: {handle.Id} on {taskQueue}");
+        return 0;
+    }
+}

--- a/src/ToolRegistryIncidentTriage/IncidentTriageWorkflow.cs
+++ b/src/ToolRegistryIncidentTriage/IncidentTriageWorkflow.cs
@@ -1,0 +1,40 @@
+using Temporalio.Common;
+using Temporalio.Workflows;
+
+namespace TemporalioSamples.ToolRegistryIncidentTriage;
+
+[Workflow("incidentTriageWorkflow")]
+public class IncidentTriageWorkflow
+{
+    private AlertPayload? currentAlert;
+    private TriageResult? result;
+
+    [WorkflowRun]
+    public async Task<TriageResult> RunAsync(AlertPayload initialAlert)
+    {
+        currentAlert = initialAlert;
+        // agenticHitl-shaped timeouts (matches lexicon-temporal's profile).
+        result = await Workflow.ExecuteActivityAsync(
+            (TriageActivity a) => a.TriageIncidentAsync(currentAlert),
+            new ActivityOptions
+            {
+                StartToCloseTimeout = TimeSpan.FromHours(8),
+                HeartbeatTimeout = TimeSpan.FromSeconds(120),
+                RetryPolicy = new RetryPolicy { MaximumAttempts = 1 },
+            });
+        return result;
+    }
+
+    [WorkflowSignal("alert-update")]
+    public Task AlertUpdateAsync(AlertPayload alert)
+    {
+        currentAlert = alert;
+        return Task.CompletedTask;
+    }
+
+    [WorkflowQuery("current-alert")]
+    public AlertPayload? CurrentAlert() => currentAlert;
+
+    [WorkflowQuery("triage-result")]
+    public TriageResult? TriageResultQuery() => result;
+}

--- a/src/ToolRegistryIncidentTriage/Program.cs
+++ b/src/ToolRegistryIncidentTriage/Program.cs
@@ -1,0 +1,28 @@
+using Temporalio.Client;
+using Temporalio.Worker;
+using TemporalioSamples.ToolRegistryIncidentTriage;
+
+var address = Environment.GetEnvironmentVariable("TEMPORAL_ADDRESS") ?? throw new InvalidOperationException("TEMPORAL_ADDRESS missing");
+var ns = Environment.GetEnvironmentVariable("TEMPORAL_NAMESPACE") ?? throw new InvalidOperationException("TEMPORAL_NAMESPACE missing");
+var apiKey = Environment.GetEnvironmentVariable("TEMPORAL_API_KEY") ?? throw new InvalidOperationException("TEMPORAL_API_KEY missing");
+var taskQueue = Environment.GetEnvironmentVariable("TEMPORAL_TASK_QUEUE") ?? "triage-dotnet";
+
+Console.WriteLine($"connecting to {address} (ns={ns}) on task queue {taskQueue}");
+
+var client = await TemporalClient.ConnectAsync(new()
+{
+    TargetHost = address,
+    Namespace = ns,
+    ApiKey = apiKey,
+    Tls = new() { },
+});
+
+using var worker = new TemporalWorker(client, new TemporalWorkerOptions(taskQueue)
+    .AddWorkflow<IncidentTriageWorkflow>()
+    .AddWorkflow<ApprovalWorkflow>()
+    .AddAllActivities(new TriageActivity()));
+
+Console.WriteLine($"worker ready — polling {taskQueue}");
+using var cts = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+await worker.ExecuteAsync(cts.Token);

--- a/src/ToolRegistryIncidentTriage/TemporalioSamples.ToolRegistryIncidentTriage.csproj
+++ b/src/ToolRegistryIncidentTriage/TemporalioSamples.ToolRegistryIncidentTriage.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- The Temporalio.Extensions.ToolRegistry SDK is in development.
+         Override the global Temporalio package reference with the local sdk-dotnet checkout
+         until the contrib package publishes. Once published, replace this whole ItemGroup
+         with: <PackageReference Include="Temporalio.Extensions.ToolRegistry" Version="..." /> -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Suppress the Directory.Build.props global Temporalio PackageReference so the
+         ProjectReference below isn't a duplicate. -->
+    <PackageReference Remove="Temporalio" />
+    <PackageReference Remove="Temporalio.Extensions.DiagnosticSource" />
+    <PackageReference Remove="Temporalio.Extensions.Hosting" />
+    <PackageReference Remove="Temporalio.Extensions.OpenTelemetry" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\sdk-dotnet\src\Temporalio\Temporalio.csproj" />
+    <ProjectReference Include="..\..\..\sdk-dotnet\src\Temporalio.Extensions.ToolRegistry\Temporalio.Extensions.ToolRegistry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ToolRegistryIncidentTriage/TriageActivity.cs
+++ b/src/ToolRegistryIncidentTriage/TriageActivity.cs
@@ -408,6 +408,10 @@ public class TriageActivity
             {
                 StartSignal = "approval-request",
                 StartSignalArgs = new[] { (object)req },
+                // If the activity retries while the approval workflow is still running,
+                // attach to the existing one rather than starting a new approval. The
+                // operator should not get a second prompt for the same incident.
+                IdConflictPolicy = Temporalio.Api.Enums.V1.WorkflowIdConflictPolicy.UseExisting,
             });
         return await handle.GetResultAsync();
     }

--- a/src/ToolRegistryIncidentTriage/TriageActivity.cs
+++ b/src/ToolRegistryIncidentTriage/TriageActivity.cs
@@ -1,0 +1,414 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Temporalio.Activities;
+using Temporalio.Client;
+using Temporalio.Extensions.ToolRegistry;
+using Temporalio.Extensions.ToolRegistry.Providers;
+
+namespace TemporalioSamples.ToolRegistryIncidentTriage;
+
+/// <summary>
+/// .NET port of the triage activity. Mirrors workers/typescript, workers/python,
+/// workers/go, workers/ruby.
+///
+/// Structure: <see cref="BuildTriageRegistry"/> returns the (registry, getResult) pair.
+/// Pure modulo TriageDeps. <see cref="TriageIncidentAsync"/> composes
+/// AgenticSession.RunWithSessionAsync + the registry + Anthropic provider.
+/// </summary>
+public class TriageActivity
+{
+    public const string SystemPrompt = """
+        You are an SRE on-call agent triaging a production alert.
+
+        You have these tools (sourced from MCP sidecars + per-language helpers):
+          - prometheus_query(query)            instant PromQL query
+          - prometheus_query_range(query, start, end, step)
+          - prometheus_alerts()                what is currently firing
+          - kubectl_get(resource, namespace?)  list K8s resources
+          - kubectl_describe(resource, name, namespace?)
+          - kubectl_logs(pod, namespace, tail?)
+          - propose_remediation(action, justification)   record but do NOT execute
+          - request_human_approval(message, diagnosis, proposedAction)
+                                               blocks until operator says approve|reject
+          - execute_remediation(action)        ONLY callable AFTER approval was approved.
+                                               Pass the same action you got approved.
+          - report_resolved(summary)           ends the loop with status=resolved
+          - report_unresolved(summary)         ends the loop with status=unresolved
+
+        Workflow:
+          1. Read the alert. Use prometheus_query to confirm the symptom is currently true.
+          2. Use kubectl_get/describe/logs and prometheus_query_range to find root cause.
+          3. propose_remediation with a specific action (e.g., "kubectl rollout restart deploy/api -n demo-app").
+          4. request_human_approval, attaching your diagnosis and the proposed action.
+          5. If approved: execute_remediation, then prometheus_query to verify the symptom is gone, then report_resolved.
+          6. If rejected: report_unresolved with the operator's reason.
+
+        Be terse. Conversation history is heartbeated to Temporal — keep tool inputs short.
+        """;
+
+    /// <summary>Pluggable I/O for the activity. Tests substitute their own.</summary>
+    public class TriageDeps
+    {
+        public required Func<string, Task<List<McpToolInfo>>> McpListTools { get; init; }
+        public required Func<string, string, IReadOnlyDictionary<string, object?>, Task<string>> McpCallTool { get; init; }
+        public required Func<AlertPayload, ApprovalRequest, Task<ApprovalResponse>> RequestHumanApproval { get; init; }
+        public required Func<string, Task<(string Stdout, string Stderr)>> ExecShellCommand { get; init; }
+    }
+
+    public record McpToolInfo(string Name, string Description, IReadOnlyDictionary<string, object?> InputSchema);
+
+    public static TriageDeps DefaultDeps() => new()
+    {
+        McpListTools = DefaultMcpListToolsAsync,
+        McpCallTool = DefaultMcpCallToolAsync,
+        RequestHumanApproval = RealRequestHumanApprovalAsync,
+        ExecShellCommand = DefaultExecShellCommandAsync,
+    };
+
+    private static readonly HttpClient http = new() { Timeout = TimeSpan.FromSeconds(30) };
+
+    private static async Task<List<McpToolInfo>> DefaultMcpListToolsAsync(string baseUrl)
+    {
+        var body = await McpRpcAsync(baseUrl, "tools/list", null).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(body);
+        var result = new List<McpToolInfo>();
+        if (!doc.RootElement.TryGetProperty("result", out var res)) return result;
+        if (!res.TryGetProperty("tools", out var tools)) return result;
+        foreach (var t in tools.EnumerateArray())
+        {
+            var name = t.GetProperty("name").GetString() ?? "";
+            var desc = t.TryGetProperty("description", out var d) ? d.GetString() ?? "" : "";
+            IReadOnlyDictionary<string, object?> schema = t.TryGetProperty("inputSchema", out var s)
+                ? JsonElementToDict(s)
+                : new Dictionary<string, object?> { ["type"] = "object" };
+            result.Add(new McpToolInfo(name, desc, schema));
+        }
+        return result;
+    }
+
+    private static async Task<string> DefaultMcpCallToolAsync(string baseUrl, string name, IReadOnlyDictionary<string, object?> args)
+    {
+        var body = await McpRpcAsync(baseUrl, "tools/call", new Dictionary<string, object?>
+        {
+            ["name"] = name,
+            ["arguments"] = args,
+        }).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(body);
+        if (doc.RootElement.TryGetProperty("error", out var err))
+        {
+            return $"MCP error: {err.GetProperty("message").GetString()}";
+        }
+        if (!doc.RootElement.TryGetProperty("result", out var res)) return "";
+        if (!res.TryGetProperty("content", out var content)) return "";
+        var parts = new List<string>();
+        foreach (var c in content.EnumerateArray())
+        {
+            if (c.TryGetProperty("text", out var text))
+            {
+                parts.Add(text.GetString() ?? "");
+            }
+        }
+        return string.Join("\n", parts);
+    }
+
+    private static async Task<string> McpRpcAsync(string baseUrl, string method, object? @params)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ["method"] = method,
+        };
+        if (@params != null) payload["params"] = @params;
+        var content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json");
+        var resp = await http.PostAsync(baseUrl, content).ConfigureAwait(false);
+        return await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+    }
+
+    private static IReadOnlyDictionary<string, object?> JsonElementToDict(JsonElement el)
+    {
+        var d = new Dictionary<string, object?>();
+        if (el.ValueKind != JsonValueKind.Object) return d;
+        foreach (var p in el.EnumerateObject())
+        {
+            d[p.Name] = p.Value.ValueKind switch
+            {
+                JsonValueKind.Object => JsonElementToDict(p.Value),
+                JsonValueKind.Array => p.Value.EnumerateArray().Select(e => e.ToString()).ToList(),
+                JsonValueKind.String => p.Value.GetString(),
+                JsonValueKind.Number => p.Value.GetDouble(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null => null,
+                _ => p.Value.ToString(),
+            };
+        }
+        return d;
+    }
+
+    private static async Task<(string, string)> DefaultExecShellCommandAsync(string cmd)
+    {
+        var psi = new ProcessStartInfo("sh", $"-c \"{cmd}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using var p = Process.Start(psi)!;
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        var completed = await Task.WhenAny(Task.Run(() => p.WaitForExit()), Task.Delay(60_000)).ConfigureAwait(false);
+        if (completed is Task<bool> b && !b.Result)
+        {
+            try { p.Kill(); } catch { }
+            throw new TimeoutException($"exec timed out: {cmd}");
+        }
+        return (await stdoutTask.ConfigureAwait(false), await stderrTask.ConfigureAwait(false));
+    }
+
+    /// <summary>
+    /// Build the tool registry plus a getter for the final result. Pure modulo deps.
+    /// Note: handlers are sync (Func&lt;..., string&gt;) per the .NET SDK signature, so
+    /// async I/O inside a handler uses .GetAwaiter().GetResult() — sync-over-async.
+    /// (See PROPOSAL_FEEDBACK.md item on SDK async-handler support.)
+    /// </summary>
+    public static (ToolRegistry Registry, Func<TriageResult?> GetResult) BuildTriageRegistry(
+        AlertPayload alert, AgenticSession session, TriageDeps deps)
+    {
+        var registry = new ToolRegistry();
+        var promMcp = Environment.GetEnvironmentVariable("MCP_PROMETHEUS_URL") ?? "http://localhost:7071/";
+        var k8sMcp = Environment.GetEnvironmentVariable("MCP_KUBERNETES_URL") ?? "http://localhost:7072/";
+
+        RegisterMcpTools(registry, promMcp, deps);
+        RegisterMcpTools(registry, k8sMcp, deps);
+
+        var remediations = new List<ProposedRemediation>();
+        string? approvedAction = null;
+        TriageResult? final = null;
+
+        registry.Register(
+            new ToolDef(
+                Name: "propose_remediation",
+                Description: "Record a remediation you would apply. Does NOT execute it.",
+                InputSchema: new Dictionary<string, object?>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object?>
+                    {
+                        ["action"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["justification"] = new Dictionary<string, object?> { ["type"] = "string" },
+                    },
+                    ["required"] = new[] { "action", "justification" },
+                }),
+            input =>
+            {
+                var r = new ProposedRemediation((string)input["action"]!, (string)input["justification"]!);
+                remediations.Add(r);
+                session.Results.Add(new Dictionary<string, object?>
+                {
+                    ["kind"] = "remediation",
+                    ["action"] = r.Action,
+                    ["justification"] = r.Justification,
+                });
+                return "recorded";
+            });
+
+        registry.Register(
+            new ToolDef(
+                Name: "request_human_approval",
+                Description: "Block until operator decides. Returns JSON {decision, reason}.",
+                InputSchema: new Dictionary<string, object?>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object?>
+                    {
+                        ["message"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["diagnosis"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["proposedAction"] = new Dictionary<string, object?> { ["type"] = "string" },
+                    },
+                    ["required"] = new[] { "message", "diagnosis", "proposedAction" },
+                }),
+            input =>
+            {
+                var req = new ApprovalRequest(
+                    (string)input["message"]!,
+                    (string)input["diagnosis"]!,
+                    (string)input["proposedAction"]!);
+                var resp = deps.RequestHumanApproval(alert, req).GetAwaiter().GetResult();
+                if (resp.Decision == "approved") approvedAction = req.ProposedAction;
+                session.Results.Add(new Dictionary<string, object?>
+                {
+                    ["kind"] = "approval",
+                    ["decision"] = resp.Decision,
+                    ["reason"] = resp.Reason,
+                });
+                return JsonSerializer.Serialize(new { decision = resp.Decision, reason = resp.Reason });
+            });
+
+        registry.Register(
+            new ToolDef(
+                Name: "execute_remediation",
+                Description: "Execute the previously-approved action. Errors if no approval has been granted.",
+                InputSchema: new Dictionary<string, object?>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object?>
+                    {
+                        ["action"] = new Dictionary<string, object?> { ["type"] = "string" },
+                    },
+                    ["required"] = new[] { "action" },
+                }),
+            input =>
+            {
+                var action = (string)input["action"]!;
+                if (approvedAction == null)
+                    return "ERROR: no approval has been granted. Call request_human_approval first.";
+                if (action != approvedAction)
+                    return $"ERROR: requested action does not match approved action. Approved: {approvedAction}";
+                var (stdout, stderr) = deps.ExecShellCommand(action).GetAwaiter().GetResult();
+                session.Results.Add(new Dictionary<string, object?>
+                {
+                    ["kind"] = "executed",
+                    ["action"] = action,
+                    ["stdout"] = Clip(stdout, 2000),
+                    ["stderr"] = Clip(stderr, 2000),
+                });
+                var output = !string.IsNullOrEmpty(stdout) ? stdout : (!string.IsNullOrEmpty(stderr) ? stderr : "ok");
+                return Clip(output, 4000);
+            });
+
+        registry.Register(
+            new ToolDef(
+                Name: "report_resolved",
+                Description: "Ends the loop with status=resolved.",
+                InputSchema: new Dictionary<string, object?>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object?>
+                    {
+                        ["summary"] = new Dictionary<string, object?> { ["type"] = "string" },
+                    },
+                    ["required"] = new[] { "summary" },
+                }),
+            input =>
+            {
+                final = new TriageResult("resolved", (string)input["summary"]!, new(remediations));
+                session.Results.Add(new Dictionary<string, object?>
+                {
+                    ["kind"] = "final",
+                    ["status"] = final.Status,
+                    ["summary"] = final.Summary,
+                });
+                return "ok";
+            });
+
+        registry.Register(
+            new ToolDef(
+                Name: "report_unresolved",
+                Description: "Ends the loop with status=unresolved.",
+                InputSchema: new Dictionary<string, object?>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object?>
+                    {
+                        ["summary"] = new Dictionary<string, object?> { ["type"] = "string" },
+                    },
+                    ["required"] = new[] { "summary" },
+                }),
+            input =>
+            {
+                final = new TriageResult("unresolved", (string)input["summary"]!, new(remediations));
+                session.Results.Add(new Dictionary<string, object?>
+                {
+                    ["kind"] = "final",
+                    ["status"] = final.Status,
+                    ["summary"] = final.Summary,
+                });
+                return "ok";
+            });
+
+        return (registry, () => final);
+    }
+
+    private static void RegisterMcpTools(ToolRegistry registry, string baseUrl, TriageDeps deps)
+    {
+        try
+        {
+            var tools = deps.McpListTools(baseUrl).GetAwaiter().GetResult();
+            foreach (var t in tools)
+            {
+                var name = t.Name;
+                registry.Register(
+                    new ToolDef(name, t.Description, t.InputSchema),
+                    input => deps.McpCallTool(baseUrl, name, input).GetAwaiter().GetResult());
+            }
+        }
+        catch
+        {
+            // MCP server unreachable during testing or boot — proceed without these tools.
+        }
+    }
+
+    public static string BuildPrompt(AlertPayload alert)
+    {
+        string Get(Dictionary<string, string> m, string k, string d) =>
+            m.TryGetValue(k, out var v) && !string.IsNullOrEmpty(v) ? v : d;
+
+        return $"Alert fired: {Get(alert.Labels, "alertname", "unknown")} on {Get(alert.Labels, "service", "unknown")}.\n"
+            + $"Summary: {Get(alert.Annotations, "summary", "(none)")}\n"
+            + $"Description: {Get(alert.Annotations, "description", "(none)")}\n"
+            + $"Runbook hint: {Get(alert.Labels, "runbook", "(none)")}\n\n"
+            + "Investigate, propose, get approval, and either fix or report unresolved.";
+    }
+
+    private static string Clip(string s, int n) => s.Length <= n ? s : s.Substring(0, n);
+
+    [Activity("triage_incident_activity")]
+    public async Task<TriageResult> TriageIncidentAsync(AlertPayload alert)
+    {
+        var deps = DefaultDeps();
+        return await AgenticSession.RunWithSessionAsync(async session =>
+        {
+            var (registry, getResult) = BuildTriageRegistry(alert, session, deps);
+            var provider = new AnthropicProvider(
+                new AnthropicConfig { ApiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY") },
+                registry,
+                SystemPrompt);
+            await session.RunToolLoopAsync(provider, registry, BuildPrompt(alert)).ConfigureAwait(false);
+            var final = getResult();
+            if (final == null)
+            {
+                throw new InvalidOperationException("Agent ended the loop without calling report_resolved or report_unresolved");
+            }
+            return final;
+        }).ConfigureAwait(false);
+    }
+
+    private static async Task<ApprovalResponse> RealRequestHumanApprovalAsync(AlertPayload alert, ApprovalRequest req)
+    {
+        var address = Environment.GetEnvironmentVariable("TEMPORAL_ADDRESS") ?? throw new InvalidOperationException("TEMPORAL_ADDRESS missing");
+        var ns = Environment.GetEnvironmentVariable("TEMPORAL_NAMESPACE") ?? throw new InvalidOperationException("TEMPORAL_NAMESPACE missing");
+        var apiKey = Environment.GetEnvironmentVariable("TEMPORAL_API_KEY") ?? throw new InvalidOperationException("TEMPORAL_API_KEY missing");
+        var taskQueue = Environment.GetEnvironmentVariable("TEMPORAL_TASK_QUEUE") ?? "triage-dotnet";
+
+        var client = await TemporalClient.ConnectAsync(new()
+        {
+            TargetHost = address,
+            Namespace = ns,
+            ApiKey = apiKey,
+            Tls = new() { },
+        });
+
+        var key = $"{(alert.Labels.GetValueOrDefault("alertname", "unknown")).ToLowerInvariant()}-{(alert.Labels.GetValueOrDefault("service", "unknown")).ToLowerInvariant()}";
+        var wfId = $"approval-{key}";
+
+        var handle = await client.StartWorkflowAsync(
+            (ApprovalWorkflow w) => w.RunAsync(key),
+            new(id: wfId, taskQueue: taskQueue)
+            {
+                StartSignal = "approval-request",
+                StartSignalArgs = new[] { (object)req },
+            });
+        return await handle.GetResultAsync();
+    }
+}

--- a/src/ToolRegistryIncidentTriage/TriageActivity.cs
+++ b/src/ToolRegistryIncidentTriage/TriageActivity.cs
@@ -413,6 +413,33 @@ public class TriageActivity
                 // operator should not get a second prompt for the same incident.
                 IdConflictPolicy = Temporalio.Api.Enums.V1.WorkflowIdConflictPolicy.UseExisting,
             });
-        return await handle.GetResultAsync();
+
+        // Heartbeat every 30 seconds while waiting on the approval workflow.
+        // AgenticSession only heartbeats between LLM turns, so a multi-hour
+        // operator wait inside this handler would otherwise trigger heartbeat
+        // timeout in 120s and kill the activity.
+        using var ticker = new System.Threading.CancellationTokenSource();
+        var tickerTask = System.Threading.Tasks.Task.Run(async () =>
+        {
+            try
+            {
+                while (!ticker.Token.IsCancellationRequested)
+                {
+                    await System.Threading.Tasks.Task.Delay(TimeSpan.FromSeconds(30), ticker.Token);
+                    Temporalio.Activities.ActivityExecutionContext.Current.Heartbeat();
+                }
+            }
+            catch (System.Threading.Tasks.TaskCanceledException) { }
+        });
+
+        try
+        {
+            return await handle.GetResultAsync();
+        }
+        finally
+        {
+            ticker.Cancel();
+            try { await tickerTask; } catch { }
+        }
     }
 }

--- a/src/ToolRegistryIncidentTriage/Types.cs
+++ b/src/ToolRegistryIncidentTriage/Types.cs
@@ -1,0 +1,20 @@
+namespace TemporalioSamples.ToolRegistryIncidentTriage;
+
+public record AlertPayload(
+    string Status,
+    Dictionary<string, string> Labels,
+    Dictionary<string, string> Annotations,
+    string StartsAt,
+    string? EndsAt = null,
+    string? Fingerprint = null);
+
+public record ProposedRemediation(string Action, string Justification);
+
+public record TriageResult(
+    string Status, // "resolved" | "unresolved"
+    string Summary,
+    List<ProposedRemediation> Remediations);
+
+public record ApprovalRequest(string Message, string Diagnosis, string ProposedAction);
+
+public record ApprovalResponse(string Decision, string Reason);

--- a/tests/TemporalioSamples.Tests.csproj
+++ b/tests/TemporalioSamples.Tests.csproj
@@ -42,6 +42,7 @@
     <ProjectReference Include="..\src\Dsl\TemporalioSamples.Dsl.csproj" />
     <ProjectReference Include="..\src\StandaloneActivity\TemporalioSamples.StandaloneActivity.csproj" />
     <ProjectReference Include="..\src\NexusMessaging\TemporalioSamples.NexusMessaging.csproj" />
+    <ProjectReference Include="..\src\ToolRegistryIncidentTriage\TemporalioSamples.ToolRegistryIncidentTriage.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/ToolRegistryIncidentTriage/TriageActivityTest.cs
+++ b/tests/ToolRegistryIncidentTriage/TriageActivityTest.cs
@@ -1,0 +1,206 @@
+using Temporalio.Extensions.ToolRegistry;
+using TemporalioSamples.ToolRegistryIncidentTriage;
+using Xunit;
+
+namespace TemporalioSamples.ToolRegistryIncidentTriage.Tests;
+
+/// <summary>
+/// Unit tests for BuildTriageRegistry. Drives the registry directly via
+/// Dispatch — bypasses RunWithSessionAsync (which requires an activity context)
+/// and the LLM provider. Mirrors the TS / Python / Go / Ruby suites.
+/// </summary>
+public class TriageActivityTest
+{
+    private static AlertPayload MakeAlert() => new(
+        Status: "firing",
+        Labels: new() { ["alertname"] = "HighLatencyP99", ["service"] = "api", ["runbook"] = "rollback-or-scale" },
+        Annotations: new() { ["summary"] = "P99 > 1s", ["description"] = "P99 above threshold for 1m." },
+        StartsAt: DateTime.UtcNow.ToString("o"));
+
+    private static TriageActivity.TriageDeps MakeDeps(
+        Func<AlertPayload, ApprovalRequest, Task<ApprovalResponse>>? approve = null,
+        Func<string, string, IReadOnlyDictionary<string, object?>, Task<string>>? mcpCall = null,
+        Func<string, Task<(string, string)>>? exec = null) =>
+        new()
+        {
+            McpListTools = baseUrl => Task.FromResult(
+                baseUrl.Contains("7071")
+                    ? new List<TriageActivity.McpToolInfo>
+                    {
+                        new("prometheus_query", "instant PromQL query",
+                            new Dictionary<string, object?>
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new Dictionary<string, object?>
+                                {
+                                    ["query"] = new Dictionary<string, object?> { ["type"] = "string" },
+                                },
+                                ["required"] = new[] { "query" },
+                            }),
+                    }
+                    : new List<TriageActivity.McpToolInfo>
+                    {
+                        new("kubectl_describe", "describe a k8s resource",
+                            new Dictionary<string, object?>
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new Dictionary<string, object?>
+                                {
+                                    ["resource"] = new Dictionary<string, object?> { ["type"] = "string" },
+                                    ["name"] = new Dictionary<string, object?> { ["type"] = "string" },
+                                    ["namespace"] = new Dictionary<string, object?> { ["type"] = "string" },
+                                },
+                                ["required"] = new[] { "resource", "name" },
+                            }),
+                    }),
+            McpCallTool = mcpCall ?? ((url, name, args) => Task.FromResult($"(mocked {name})")),
+            RequestHumanApproval = approve ?? ((alert, req) => Task.FromResult(new ApprovalResponse("approved", "default-mock"))),
+            ExecShellCommand = exec ?? (cmd => Task.FromResult(($"(mocked exec: {cmd})", ""))),
+        };
+
+    private record Call(string Name, IReadOnlyDictionary<string, object?> Input);
+
+    private static (TriageResult? result, IList<IDictionary<string, object?>> sessionResults) Drive(
+        TriageActivity.TriageDeps deps, params Call[] calls)
+    {
+        var session = new AgenticSession();
+        var (registry, getResult) = TriageActivity.BuildTriageRegistry(MakeAlert(), session, deps);
+        foreach (var c in calls)
+        {
+            registry.Dispatch(c.Name, c.Input);
+        }
+        return (getResult(), session.Results);
+    }
+
+    [Fact]
+    public void HappyPathResolved()
+    {
+        int approvalCalls = 0;
+        var deps = MakeDeps(approve: (a, r) =>
+        {
+            approvalCalls++;
+            return Task.FromResult(new ApprovalResponse("approved", "go ahead"));
+        });
+        var action = "kubectl rollout restart deploy/api -n demo-app";
+
+        var (result, sessionResults) = Drive(deps,
+            new Call("prometheus_query", new Dictionary<string, object?> { ["query"] = "up{service='api'}" }),
+            new Call("kubectl_describe", new Dictionary<string, object?> { ["resource"] = "pod", ["name"] = "api-xyz", ["namespace"] = "demo-app" }),
+            new Call("propose_remediation", new Dictionary<string, object?> { ["action"] = action, ["justification"] = "leak; restart reclaims memory" }),
+            new Call("request_human_approval", new Dictionary<string, object?>
+            {
+                ["message"] = "Restart api?",
+                ["diagnosis"] = "memory leak",
+                ["proposedAction"] = action,
+            }),
+            new Call("execute_remediation", new Dictionary<string, object?> { ["action"] = action }),
+            new Call("report_resolved", new Dictionary<string, object?> { ["summary"] = "restarted; latency normal" }));
+
+        Assert.NotNull(result);
+        Assert.Equal("resolved", result!.Status);
+        Assert.Contains("restart", result.Summary);
+        Assert.Single(result.Remediations);
+        Assert.Equal(action, result.Remediations[0].Action);
+        Assert.Equal(1, approvalCalls);
+        Assert.Equal(new[] { "remediation", "approval", "executed", "final" },
+            sessionResults.Select(r => (string)r["kind"]!));
+    }
+
+    [Fact]
+    public void RejectedApprovalUnresolved()
+    {
+        var deps = MakeDeps(approve: (a, r) => Task.FromResult(new ApprovalResponse("rejected", "off-hours; defer until tomorrow")));
+
+        var (result, sessionResults) = Drive(deps,
+            new Call("propose_remediation", new Dictionary<string, object?> { ["action"] = "kubectl scale ...", ["justification"] = "transient" }),
+            new Call("request_human_approval", new Dictionary<string, object?>
+            {
+                ["message"] = "Scale?",
+                ["diagnosis"] = "transient",
+                ["proposedAction"] = "kubectl scale ...",
+            }),
+            new Call("report_unresolved", new Dictionary<string, object?> { ["summary"] = "operator deferred" }));
+
+        Assert.Equal("unresolved", result!.Status);
+        Assert.Contains("deferred", result.Summary);
+        var approval = sessionResults.FirstOrDefault(r => (string)r["kind"]! == "approval");
+        Assert.NotNull(approval);
+        Assert.Equal("rejected", approval!["decision"]);
+        Assert.Contains("off-hours", (string)approval["reason"]!);
+    }
+
+    [Fact]
+    public void ExecuteRefusesWithoutApproval()
+    {
+        string? executedCmd = null;
+        var deps = MakeDeps(exec: cmd => { executedCmd = cmd; return Task.FromResult(("ran", "")); });
+
+        var (result, _) = Drive(deps,
+            new Call("execute_remediation", new Dictionary<string, object?> { ["action"] = "rm -rf /" }),
+            new Call("report_unresolved", new Dictionary<string, object?> { ["summary"] = "tried to skip approval" }));
+
+        Assert.Equal("unresolved", result!.Status);
+        Assert.Null(executedCmd);
+    }
+
+    [Fact]
+    public void ExecuteRefusesWhenActionDoesNotMatch()
+    {
+        string? executedCmd = null;
+        var deps = MakeDeps(
+            approve: (a, r) => Task.FromResult(new ApprovalResponse("approved", "ok")),
+            exec: cmd => { executedCmd = cmd; return Task.FromResult(("ran", "")); });
+
+        var (result, _) = Drive(deps,
+            new Call("propose_remediation", new Dictionary<string, object?> { ["action"] = "kubectl restart api", ["justification"] = "x" }),
+            new Call("request_human_approval", new Dictionary<string, object?>
+            {
+                ["message"] = "Restart?",
+                ["diagnosis"] = "x",
+                ["proposedAction"] = "kubectl restart api",
+            }),
+            new Call("execute_remediation", new Dictionary<string, object?> { ["action"] = "kubectl scale deploy/api --replicas=10" }),
+            new Call("report_unresolved", new Dictionary<string, object?> { ["summary"] = "guard tripped" }));
+
+        Assert.Equal("unresolved", result!.Status);
+        Assert.Null(executedCmd);
+    }
+
+    [Fact]
+    public void McpToolsRegistered()
+    {
+        var deps = MakeDeps();
+        var session = new AgenticSession();
+        var (registry, _) = TriageActivity.BuildTriageRegistry(MakeAlert(), session, deps);
+        var names = registry.Definitions.Select(d => d.Name).ToList();
+        foreach (var want in new[]
+        {
+            "prometheus_query", "kubectl_describe",
+            "propose_remediation", "request_human_approval",
+            "execute_remediation", "report_resolved", "report_unresolved",
+        })
+        {
+            Assert.Contains(want, names);
+        }
+    }
+
+    [Fact]
+    public void McpDispatchForwardsToSidecar()
+    {
+        var calls = new List<(string Url, string Name, IReadOnlyDictionary<string, object?> Args)>();
+        var deps = MakeDeps(mcpCall: (url, name, args) =>
+        {
+            calls.Add((url, name, args));
+            return Task.FromResult($"result for {name}");
+        });
+
+        Drive(deps,
+            new Call("prometheus_query", new Dictionary<string, object?> { ["query"] = "up{}" }),
+            new Call("report_unresolved", new Dictionary<string, object?> { ["summary"] = "test" }));
+
+        Assert.Single(calls);
+        Assert.Equal("prometheus_query", calls[0].Name);
+        Assert.Contains("7071", calls[0].Url);
+        Assert.Equal("up{}", calls[0].Args["query"]);
+    }
+}


### PR DESCRIPTION
Adds a new sample under `src/ToolRegistryIncidentTriage/` demonstrating `Temporalio.Extensions.ToolRegistry` end-to-end.

The example includes:

- Long-running activity wrapped in `AgenticSession` with heartbeat checkpointing.
- MCP HTTP integration via the sidecar pattern (Prometheus + Kubernetes MCP servers).
- Human-in-the-loop tool calls via a companion workflow (deterministic ID, two signals, one query).
- A testable activity refactor: `BuildTriageRegistry(alert, session, deps)` plus a `TriageDeps` record of I/O callables, so unit tests substitute fakes and drive the registry via `MockProvider`.

xUnit tests in `tests/ToolRegistryIncidentTriage/TriageActivityTest.cs` use `MockProvider` and require no API key or running Temporal server.

Conventions followed:
- `.csproj` renamed to `TemporalioSamples.ToolRegistryIncidentTriage.csproj` per `Bedrock.Basic` / `Dsl` pattern.
- Tests at `tests/ToolRegistryIncidentTriage/`, registered in `tests/TemporalioSamples.Tests.csproj`.
- Added to `TemporalioSamples.sln` via `dotnet sln add`.
- Added entry to root `README.md` example list (alphabetical).

**Known transitional issue:** the csproj overrides `Directory.Build.props`'s global `Temporalio` `PackageReference` with a `ProjectReference` to `../../../sdk-dotnet/src/Temporalio.Extensions.ToolRegistry/`, since the `Temporalio.Extensions.ToolRegistry` package isn't published yet. Building the project locally requires the sdk-dotnet Rust bridge to be built first (`cd ../sdk-dotnet/src/Temporalio/Bridge && cargo build` or equivalent). Will switch to `PackageReference` once `Temporalio.Extensions.ToolRegistry` ships.

The override also disables `TreatWarningsAsErrors` and `EnableNETAnalyzers` for this project, mirroring concerns flagged in temporalio/sdk-dotnet#641 about analyzers running over `ProjectReference` source.

Cross-references the SDK PR (temporalio/sdk-dotnet#641) which adds the `Temporalio.Extensions.ToolRegistry` extension itself.