### PR TITLE
Central package management and SDK version update

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,10 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Temporalio" Version="1.14.0" />
-    <PackageReference Include="Temporalio.Extensions.DiagnosticSource" Version="1.14.0" />
-    <PackageReference Include="Temporalio.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="Temporalio.Extensions.OpenTelemetry" Version="1.14.0" />
+    <PackageReference Include="Temporalio" />
+    <PackageReference Include="Temporalio.Extensions.DiagnosticSource" />
+    <PackageReference Include="Temporalio.Extensions.Hosting" />
+    <PackageReference Include="Temporalio.Extensions.OpenTelemetry" />
     <!--
     Can also reference the SDK downloaded to a local directory:
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\temporal-sdk-dotnet\src\Temporalio\Temporalio.csproj" />
@@ -30,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,29 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AWSSDK.BedrockRuntime" Version="3.7.401.11" />
+    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" />
+    <PackageVersion Include="NexusRpc" Version="0.3.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="Temporalio" Version="1.14.1" />
+    <PackageVersion Include="Temporalio.Extensions.DiagnosticSource" Version="1.14.1" />
+    <PackageVersion Include="Temporalio.Extensions.Hosting" Version="1.14.1" />
+    <PackageVersion Include="Temporalio.Extensions.OpenTelemetry" Version="1.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.console" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="YamlDotNet" Version="16.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/AspNet/Worker/TemporalioSamples.AspNet.Worker.csproj
+++ b/src/AspNet/Worker/TemporalioSamples.AspNet.Worker.csproj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 </Project>

--- a/src/Bedrock/Basic/TemporalioSamples.Bedrock.Basic.csproj
+++ b/src/Bedrock/Basic/TemporalioSamples.Bedrock.Basic.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.401.11" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" />
   </ItemGroup>
 
 </Project>

--- a/src/Bedrock/Entity/TemporalioSamples.Bedrock.Entity.csproj
+++ b/src/Bedrock/Entity/TemporalioSamples.Bedrock.Entity.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.401.11" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" />
   </ItemGroup>
 
 </Project>

--- a/src/Bedrock/SignalsAndQueries/TemporalioSamples.Bedrock.SignalsAndQueries.csproj
+++ b/src/Bedrock/SignalsAndQueries/TemporalioSamples.Bedrock.SignalsAndQueries.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.401.11" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" />
   </ItemGroup>
 
 </Project>

--- a/src/ClientMtls/TemporalioSamples.ClientMtls.csproj
+++ b/src/ClientMtls/TemporalioSamples.ClientMtls.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
 </Project>

--- a/src/DependencyInjection/TemporalioSamples.DependencyInjection.csproj
+++ b/src/DependencyInjection/TemporalioSamples.DependencyInjection.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 </Project>

--- a/src/Dsl/TemporalioSamples.Dsl.csproj
+++ b/src/Dsl/TemporalioSamples.Dsl.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="16.2.0" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NexusCancellation/TemporalioSamples.NexusCancellation.csproj
+++ b/src/NexusCancellation/TemporalioSamples.NexusCancellation.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NexusRpc" Version="0.3.0" />
+    <PackageReference Include="NexusRpc" />
   </ItemGroup>
 
 </Project>

--- a/src/NexusContextPropagation/TemporalioSamples.NexusContextPropagation.csproj
+++ b/src/NexusContextPropagation/TemporalioSamples.NexusContextPropagation.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\ContextPropagation\TemporalioSamples.ContextPropagation.csproj" />
-    <PackageReference Include="NexusRpc" Version="0.3.0" />
+    <PackageReference Include="NexusRpc" />
   </ItemGroup>
 
 </Project>

--- a/src/NexusMessaging/TemporalioSamples.NexusMessaging.csproj
+++ b/src/NexusMessaging/TemporalioSamples.NexusMessaging.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NexusRpc" Version="0.3.0" />
+    <PackageReference Include="NexusRpc" />
   </ItemGroup>
 
 </Project>

--- a/src/NexusMultiArg/TemporalioSamples.NexusMultiArg.csproj
+++ b/src/NexusMultiArg/TemporalioSamples.NexusMultiArg.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NexusRpc" Version="0.3.0" />
+    <PackageReference Include="NexusRpc" />
   </ItemGroup>
 
 </Project>

--- a/src/NexusSimple/TemporalioSamples.NexusSimple.csproj
+++ b/src/NexusSimple/TemporalioSamples.NexusSimple.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NexusRpc" Version="0.3.0" />
+    <PackageReference Include="NexusRpc" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry/CoreSdkForwarding/TemporalioSamples.OpenTelemetry.CoreSdkForwarding.csproj
+++ b/src/OpenTelemetry/CoreSdkForwarding/TemporalioSamples.OpenTelemetry.CoreSdkForwarding.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry/DotNetMetrics/TemporalioSamples.OpenTelemetry.DotNetMetrics.csproj
+++ b/src/OpenTelemetry/DotNetMetrics/TemporalioSamples.OpenTelemetry.DotNetMetrics.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
   </ItemGroup>
 
 </Project>

--- a/tests/TemporalioSamples.Tests.csproj
+++ b/tests/TemporalioSamples.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
-    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.console" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.console" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Update Temporal .NET SDK to 1.14.1
- Refactor package versions to be centrally managed.
