### PR TITLE
chore: update Temporal .NET SDK to 1.16.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,10 +17,10 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="Temporalio" Version="1.15.0" />
-    <PackageVersion Include="Temporalio.Extensions.DiagnosticSource" Version="1.15.0" />
-    <PackageVersion Include="Temporalio.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="Temporalio.Extensions.OpenTelemetry" Version="1.15.0" />
+    <PackageVersion Include="Temporalio" Version="1.16.0" />
+    <PackageVersion Include="Temporalio.Extensions.DiagnosticSource" Version="1.16.0" />
+    <PackageVersion Include="Temporalio.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="Temporalio.Extensions.OpenTelemetry" Version="1.16.0" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.4" Condition="'$(MSBuildProjectName)' != 'TemporalioSamples.SampleAppHost'" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.console" Version="2.9.3" />


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update Temporal .NET SDK version to 1.15.0

## Why?

Use latest Temporal .NET SDK