### PR TITLE
chore: update Aspire version, drop MessagePack

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,11 +4,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.4" Condition="'$(MSBuildProjectName)' != 'TemporalioSamples.SampleAppHost'" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" Condition="'$(MSBuildProjectName)' != 'TemporalioSamples.SampleAppHost'" />
     <PackageVersion Include="AWSSDK.BedrockRuntime" Version="4.0.100" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
-    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.28" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />

--- a/src/AspireIntegrations/Temporal.Extensions.Aspire.Hosting/Temporal.Extensions.Aspire.Hosting.csproj
+++ b/src/AspireIntegrations/Temporal.Extensions.Aspire.Hosting/Temporal.Extensions.Aspire.Hosting.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.AppHost" />
-        <PackageReference Include="MessagePack" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />
     </ItemGroup>
 </Project>

--- a/src/AspireIntegrations/TemporalioSamples.SampleAppHost/TemporalioSamples.SampleAppHost.csproj
+++ b/src/AspireIntegrations/TemporalioSamples.SampleAppHost/TemporalioSamples.SampleAppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.4">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Update Aspire to latest version.
- Remove MessagePack direct reference.

## Why?

MessagePack is only referenced transitively through Aspire and the latest Aspire versions use a non-vulnerable version of MessagePack.