### PR TITLE
Forward core logs to ILogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Prerequisites:
     and sends messages to it.
 * [NexusMultiArg](src/NexusMultiArg) - Nexus service implementation calling a workflow with multiple arguments.
 * [NexusSimple](src/NexusSimple) - Simple Nexus service implementation.
-* [OpenTelemetry](src/OpenTelemetry) - Demonstrates how to set up OpenTelemetry tracing and metrics for both the client and worker, using both the .NET metrics API and internal forwarding from the Core SDK.
+* [OpenTelemetry](src/OpenTelemetry) - Demonstrates how to set up OpenTelemetry tracing and metrics for both the client and worker, using both the .NET metrics API and internal forwarding from the Core SDK. Also shows how to forward internal Core SDK logs to an `ILogger`.
 * [Patching](src/Patching) - Alter workflows safely with Patch and DeprecatePatch.
 * [Polling](src/Polling) - Recommended implementation of an activity that needs to periodically poll an external resource waiting its successful completion.
 * [SafeMessageHandlers](src/SafeMessageHandlers) - Use `Semaphore` to ensure operations are atomically processed in a workflow.

--- a/src/AspNet/README.md
+++ b/src/AspNet/README.md
@@ -2,6 +2,9 @@
 
 This sample shows how to create a generic host worker for a workflow and an ASP.NET web application that starts it.
 
+The worker also uses `LogForwardingOptions` to forward logs from the internal Core SDK, which are otherwise written to
+the console and never seen by `ILogger`, to the host's injected logger factory.
+
 To run, first see [README.md](../../README.md) for prerequisites. Then, start the worker by running the following in the
 [Worker](Worker) directory:
 

--- a/src/AspNet/Worker/Program.cs
+++ b/src/AspNet/Worker/Program.cs
@@ -1,15 +1,35 @@
 using Temporalio.Extensions.Hosting;
+using Temporalio.Runtime;
 using TemporalioSamples.AspNet.Worker;
 
 IHost host = Host.CreateDefaultBuilder(args)
     .ConfigureLogging(ctx =>
         ctx.AddSimpleConsole().SetMinimumLevel(LogLevel.Information))
     .ConfigureServices(ctx =>
-        ctx.AddHostedTemporalWorker(
+    {
+        // Add the client the worker will use. The Core SDK writes its logs to the console itself
+        // unless Forwarding is set, in which case they go to the injected ILogger.
+        ctx.AddTemporalClient(
             clientTargetHost: "localhost:7233",
-            clientNamespace: "default",
-            taskQueue: MyWorkflow.TaskQueue).
-        AddWorkflow<MyWorkflow>())
+            clientNamespace: "default").
+            Configure<ILoggerFactory>((options, loggerFactory) =>
+                options.Runtime = new TemporalRuntime(new TemporalRuntimeOptions()
+                {
+                    Telemetry = new TelemetryOptions()
+                    {
+                        Logging = new LoggingOptions()
+                        {
+                            // Core SDK logs default to WARN; lowered here so there is more to see.
+                            Filter = new TelemetryFilterOptions(core: TelemetryFilterOptions.Level.Info),
+                            Forwarding = new LogForwardingOptions(loggerFactory.CreateLogger("Temporalio.Core")),
+                        },
+                    },
+                }));
+
+        // Add the worker, which uses the injected client
+        ctx.AddHostedTemporalWorker(MyWorkflow.TaskQueue).
+            AddWorkflow<MyWorkflow>();
+    })
     .Build();
 
 host.Run();

--- a/src/DependencyInjection/Program.cs
+++ b/src/DependencyInjection/Program.cs
@@ -1,6 +1,7 @@
 using Temporalio.Client;
 using Temporalio.Common.EnvConfig;
 using Temporalio.Extensions.Hosting;
+using Temporalio.Runtime;
 using TemporalioSamples.DependencyInjection;
 
 async Task RunWorkerAsync()
@@ -9,17 +10,35 @@ async Task RunWorkerAsync()
         .ConfigureLogging(ctx =>
             ctx.AddSimpleConsole().SetMinimumLevel(LogLevel.Information))
         .ConfigureServices(ctx =>
-            ctx.
-                // Add the database client at the scoped level
-                AddScoped<IMyDatabaseClient, MyDatabaseClient>().
-                // Add the worker
-                AddHostedTemporalWorker(
-                    clientTargetHost: "localhost:7233",
-                    clientNamespace: "default",
-                    taskQueue: "dependency-injection-sample").
+        {
+            // Add the database client at the scoped level
+            ctx.AddScoped<IMyDatabaseClient, MyDatabaseClient>();
+
+            // Add the client the worker will use. The Core SDK writes its logs to the console
+            // itself unless Forwarding is set, in which case they go to the injected ILogger.
+            ctx.AddTemporalClient(
+                clientTargetHost: "localhost:7233",
+                clientNamespace: "default").
+                Configure<ILoggerFactory>((options, loggerFactory) =>
+                    options.Runtime = new TemporalRuntime(new TemporalRuntimeOptions()
+                    {
+                        Telemetry = new TelemetryOptions()
+                        {
+                            Logging = new LoggingOptions()
+                            {
+                                // Core SDK logs default to WARN; lowered here so there is more to see.
+                                Filter = new TelemetryFilterOptions(core: TelemetryFilterOptions.Level.Info),
+                                Forwarding = new LogForwardingOptions(loggerFactory.CreateLogger("Temporalio.Core")),
+                            },
+                        },
+                    }));
+
+            // Add the worker, which uses the injected client
+            ctx.AddHostedTemporalWorker("dependency-injection-sample").
                 // Add the activities class at the scoped level
                 AddScopedActivities<MyActivities>().
-                AddWorkflow<MyWorkflow>())
+                AddWorkflow<MyWorkflow>();
+        })
         .Build();
     await host.RunAsync();
 }

--- a/src/DependencyInjection/README.md
+++ b/src/DependencyInjection/README.md
@@ -1,6 +1,10 @@
 # Dependency Injection
 
-This sample shows an activity having a dependency injected and a worker running as a generic host.
+This sample shows an activity having a dependency injected and a worker running as a generic host with an injected
+`ITemporalClient`.
+
+It also uses `LogForwardingOptions` to forward logs from the internal Core SDK, which are otherwise written to the
+console and never seen by `ILogger`, to the host's injected logger factory.
 
 To run, first see [README.md](../../README.md) for prerequisites. Then, run the following from this directory
 in a separate terminal to start the worker:

--- a/src/OpenTelemetry/CoreSdkForwarding/Program.cs
+++ b/src/OpenTelemetry/CoreSdkForwarding/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using OpenTelemetry;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -25,13 +26,24 @@ using var tracerProvider = Sdk.
     AddOtlpExporter().
     Build();
 
+// Shared by the client and by Core SDK log forwarding below. The OpenTelemetry provider exports
+// logs to the dashboard alongside the traces and metrics.
+using var loggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        AddOpenTelemetry(options =>
+        {
+            options.SetResourceBuilder(resourceBuilder);
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+            options.AddOtlpExporter();
+        }).
+        SetMinimumLevel(LogLevel.Information));
+
 // Create a client to localhost on default namespace
 var connectOptions = ClientEnvConfig.LoadClientConnectOptions();
 connectOptions.TargetHost ??= "localhost:7233";
-connectOptions.LoggerFactory = LoggerFactory.Create(builder =>
-    builder.
-        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-        SetMinimumLevel(LogLevel.Information));
+connectOptions.LoggerFactory = loggerFactory;
 connectOptions.Interceptors = new[] { new TracingInterceptor() };
 connectOptions.Runtime = new TemporalRuntime(new TemporalRuntimeOptions()
 {
@@ -43,6 +55,15 @@ connectOptions.Runtime = new TemporalRuntime(new TemporalRuntimeOptions()
             {
                 Url = new Uri("http://localhost:4317"),
             },
+        },
+        Logging = new LoggingOptions()
+        {
+            // Core SDK logs default to WARN; lowered here so there is more to see.
+            Filter = new TelemetryFilterOptions(core: TelemetryFilterOptions.Level.Info),
+
+            // The Core SDK writes its logs to the console itself unless Forwarding is set, in
+            // which case they go to this ILogger instead.
+            Forwarding = new LogForwardingOptions(loggerFactory.CreateLogger("Temporalio.Core")),
         },
     },
 });

--- a/src/OpenTelemetry/CoreSdkForwarding/README.md
+++ b/src/OpenTelemetry/CoreSdkForwarding/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry - .Core SDK Forwarding
 
-This sample shows how to configure the SDK to forward metrics from the Core SDK.
+This sample shows how to configure the SDK to forward metrics and logs from the Core SDK.
 
 The main advantage over using .NET metrics is simplicity.
 
@@ -39,3 +39,24 @@ Select `temporal-core-sdk`.
 All metrics emitted by the Core SDK will be shown. It may look something like:
 
 ![Metrics Screenshot](metrics-screenshot.png)
+
+## Logs
+
+The Core SDK writes its own logs to the console, where `ILogger` never sees them. Setting `Forwarding` on
+`LoggingOptions` routes them to the given logger instead:
+
+```csharp
+Logging = new LoggingOptions()
+{
+    // Core SDK logs default to WARN for Temporal's crates, ERROR for everything else.
+    Filter = new TelemetryFilterOptions(core: TelemetryFilterOptions.Level.Info),
+    Forwarding = new LogForwardingOptions(loggerFactory.CreateLogger("Temporalio.Core")),
+}
+```
+
+Forwarded logs are prefixed with their Core SDK target:
+
+    [10:45:27] info: Temporalio.Core[0]
+          [sdk_core::temporalio_sdk_core::worker] Initializing worker namespace="default", task_queue="opentelemetry-sample-core-sdk-forwarding"
+
+Since the logger factory here also has an OpenTelemetry provider, they show up on the dashboard's structured logs tab.

--- a/src/OpenTelemetry/DotNetMetrics/Program.cs
+++ b/src/OpenTelemetry/DotNetMetrics/Program.cs
@@ -35,13 +35,16 @@ using var meterProvider = Sdk.
     AddOtlpExporter().
     Build();
 
+// Shared by the client and by Core SDK log forwarding below.
+using var loggerFactory = LoggerFactory.Create(builder =>
+    builder.
+        AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
+        SetMinimumLevel(LogLevel.Information));
+
 // Create a client to localhost on default namespace
 var client = await TemporalClient.ConnectAsync(new("localhost:7233")
 {
-    LoggerFactory = LoggerFactory.Create(builder =>
-        builder.
-            AddSimpleConsole(options => options.TimestampFormat = "[HH:mm:ss] ").
-            SetMinimumLevel(LogLevel.Information)),
+    LoggerFactory = loggerFactory,
     Interceptors = new[] { new TracingInterceptor() },
     Runtime = new TemporalRuntime(new TemporalRuntimeOptions()
     {
@@ -50,6 +53,15 @@ var client = await TemporalClient.ConnectAsync(new("localhost:7233")
             Metrics = new MetricsOptions()
             {
                 CustomMetricMeter = new CustomMetricMeter(meter),
+            },
+            Logging = new LoggingOptions()
+            {
+                // Core SDK logs default to WARN; lowered here so there is more to see.
+                Filter = new TelemetryFilterOptions(core: TelemetryFilterOptions.Level.Info),
+
+                // The Core SDK writes its logs to the console itself unless Forwarding is set, in
+                // which case they go to this ILogger instead.
+                Forwarding = new LogForwardingOptions(loggerFactory.CreateLogger("Temporalio.Core")),
             },
         },
     }),

--- a/src/OpenTelemetry/DotNetMetrics/README.md
+++ b/src/OpenTelemetry/DotNetMetrics/README.md
@@ -43,3 +43,19 @@ Similar to traces, you can select either `worker` or `workflow`.
 `workflow` will show the metrics emitted by the client. It may look something like:
 
 ![Client Metrics Screenshot](client-metrics-screenshot.png)
+
+## Logs
+
+The Core SDK writes its own logs to the console, where `ILogger` never sees them. Setting `Forwarding` on
+`LoggingOptions` routes them to the given logger instead:
+
+```csharp
+Logging = new LoggingOptions()
+{
+    // Core SDK logs default to WARN for Temporal's crates, ERROR for everything else.
+    Filter = new TelemetryFilterOptions(core: TelemetryFilterOptions.Level.Info),
+    Forwarding = new LogForwardingOptions(loggerFactory.CreateLogger("Temporalio.Core")),
+}
+```
+
+This sample sends them to the console, but any provider works.

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -8,3 +8,6 @@ Demonstrates how to use OpenTelemetry tracing and metrics with the .NET SDK. The
   a .NET `Meter` that can then be used with OpenTelemetry.
 
 Both of these samples use the same OpenTelemetry tracing approach but have different metrics approaches.
+
+Both also use `LogForwardingOptions` to forward logs from the internal Core logic, which are otherwise written to the
+console and never seen by `ILogger`.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Set `Telemetry.Logging.Forwarding` in examples so that logs from core library flow through `Microsoft.Extensions.Logging`. Updated in the `Aspnet`, `DependencyInjection`, and `OpenTelemetry` samples.

## Why?

Demonstrate how to push logs through the built-in unified logging system in .NET applications.

## Checklist
<!--- add/delete as needed --->

1. Closes #217 

2. How was this tested: Manually run samples

3. Any docs updates needed? No
