### PR TITLE
Add Nexus to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,10 @@
 * @temporalio/sdk
+
+# SDK & Nexus teams share ownership of these files
+/README.md @temporalio/sdk @temporalio/nexus
+/TemporalioSamples.sln @temporalio/sdk @temporalio/nexus
+/tests/TemporalioSamples.Tests.csproj @temporalio/sdk @temporalio/nexus
+
+# The Nexus team owns any folder whose name starts with "Nexus"
+/src/Nexus*/ @temporalio/nexus
+/tests/Nexus*/ @temporalio/nexus


### PR DESCRIPTION
## What was changed
Add the Nexus team as codeowners for samples and tests that start with "nexus". Also, add the Nexus team as co-owners of the `README` and project files.
