### PR TITLE
Cap CI jobs at 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - os: ubuntu-arm
             runsOn: ubuntu-24.04-arm64-2-core
     runs-on: ${{ matrix.runsOn || matrix.os }}
+    timeout-minutes: 30
     steps:
       - name: Print build information
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}"


### PR DESCRIPTION
The CI workflow sets no `timeout-minutes`, so a hung job burns GitHub's 6-hour default before failing — this bit temporalio/samples-python twice (a 360-minute job on `main` and a 4.5-hour hang on a PR) before temporalio/samples-python#364 added a cap there. Recent jobs finish in ~4 minutes, so a 30-minute cap is generous headroom while turning a hang into a fast, visible failure instead of a stuck PR.